### PR TITLE
Added a new "getall" ( or "all" command which downloads all objects (certs + license + assets) at once

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,8 @@ using SAS Viya Orders CLI:
    --config /sasstuff/.viya4-orders-cli.yaml --file-path /sasstuff/sasfiles --file-name 923456_lts_depassets
   ```
 
+  NOTE: the `--file-name` option is not applicable when using the `getall` command
+  
   Sample output:
 
   ```text

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Available Commands:
   deploymentAssets Download deployment assets for the given order number at the given cadence name and version - if version not specified, get the latest version of the given cadence name
   help             Help about any command
   license          Download a license for the given order number at the given cadence name and version
+  getall           Download license + certificates + deploymentAssests for the given order number at the given cadence name and version
 
 Flags:
   -c, --config string      config file (default is $HOME/.viya4-orders-cli)

--- a/cmd/getall.go
+++ b/cmd/getall.go
@@ -5,6 +5,7 @@ package cmd
 
 import (
 	"log"
+	"sync"
 
 	"github.com/sassoftware/viya4-orders-cli/lib/assetreqs"
 	"github.com/spf13/cobra"
@@ -19,23 +20,40 @@ var getallCmd = &cobra.Command{
 	Aliases: []string{"all"},
 	Args:    cobra.ExactArgs(3),
 	Run: func(cmd *cobra.Command, args []string) {
-		ar := assetreqs.New(token, "license", args[0], args[1], args[2], assetFilePath, "", outFormat, allowUnsuppd)
-		err := ar.GetAsset()
-		if err != nil {
-			log.Fatalln(err)
-		}
 
-		ar = assetreqs.New(token, "deploymentAssets", args[0], args[1], args[2], assetFilePath, "", outFormat, allowUnsuppd)
-		err = ar.GetAsset()
-		if err != nil {
-			log.Fatalln(err)
-		}
+		var wg sync.WaitGroup
 
-		ar = assetreqs.New(token, "certificates", args[0], "", "", assetFilePath, "", outFormat, allowUnsuppd)
-		err = ar.GetAsset()
-		if err != nil {
-			log.Fatalln(err)
-		}
+		wg.Add(3)
+
+		go func() {
+			ar := assetreqs.New(token, "license", args[0], args[1], args[2], assetFilePath, "", outFormat, allowUnsuppd)
+			err := ar.GetAsset()
+			if err != nil {
+				log.Fatalln(err)
+			}
+			wg.Done()
+		}()
+
+		go func() {
+			ar := assetreqs.New(token, "deploymentAssets", args[0], args[1], args[2], assetFilePath, "", outFormat, allowUnsuppd)
+			err := ar.GetAsset()
+			if err != nil {
+				log.Fatalln(err)
+			}
+			wg.Done()
+		}()
+
+		go func() {
+			ar := assetreqs.New(token, "certificates", args[0], "", "", assetFilePath, "", outFormat, allowUnsuppd)
+			err := ar.GetAsset()
+			if err != nil {
+				log.Fatalln(err)
+			}
+			wg.Done()
+		}()
+
+		wg.Wait()
+
 	},
 }
 

--- a/cmd/getall.go
+++ b/cmd/getall.go
@@ -1,0 +1,44 @@
+// Copyright © 2020-2023, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"log"
+
+	"github.com/sassoftware/viya4-orders-cli/lib/assetreqs"
+	"github.com/spf13/cobra"
+)
+
+// getallCmd represents the getall command
+var getallCmd = &cobra.Command{
+	Use:   "getall [order number] [cadence name] [cadence version]",
+	Short: "Download all downloadable objects (assets + license + certs) for the given order number at the given cadence name and version	",
+	Example: "viya4-orders-cli getall 993456 stable 2020.0.3\n" +
+		"viya4-orders-cli getall 993456 stable 2020.0.3 -p $HOME/sas -n license_993456_stable_2020.0.3",
+	Aliases: []string{"all"},
+	Args:    cobra.ExactArgs(3),
+	Run: func(cmd *cobra.Command, args []string) {
+		ar := assetreqs.New(token, "license", args[0], args[1], args[2], assetFilePath, "", outFormat, allowUnsuppd)
+		err := ar.GetAsset()
+		if err != nil {
+			log.Fatalln(err)
+		}
+
+		ar = assetreqs.New(token, "deploymentAssets", args[0], args[1], args[2], assetFilePath, "", outFormat, allowUnsuppd)
+		err = ar.GetAsset()
+		if err != nil {
+			log.Fatalln(err)
+		}
+
+		ar = assetreqs.New(token, "certificates", args[0], "", "", assetFilePath, "", outFormat, allowUnsuppd)
+		err = ar.GetAsset()
+		if err != nil {
+			log.Fatalln(err)
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(getallCmd)
+}


### PR DESCRIPTION
Added a new "getall" (or "all" alias) command which downloads all objects (certs + license + assets) at once.
The command runs all three downloads in parallel.
Updated README.md with explanation about this new command.